### PR TITLE
Make Registries singleton isolate the cache

### DIFF
--- a/src/core/Wemogy.CQRS.UnitTests/Commands/Registries/CommandRunnerRegistryTests.cs
+++ b/src/core/Wemogy.CQRS.UnitTests/Commands/Registries/CommandRunnerRegistryTests.cs
@@ -16,7 +16,7 @@ public class CommandRunnerRegistryTests
         var serviceCollection = new ServiceCollection();
         serviceCollection.AddTestApplication();
         var serviceProvider = serviceCollection.BuildServiceProvider();
-        var commandRunnerRegistry = new CommandRunnerRegistry(serviceProvider);
+        var commandRunnerRegistry = new CommandRunnerRegistry();
         var createUserCommand = new CreateUserCommand
         {
             Firstname = "John"
@@ -31,7 +31,7 @@ public class CommandRunnerRegistryTests
             },
             _ =>
             {
-                commandRunnerRegistry.ExecuteCommandRunnerAsync(createUserCommand);
+                commandRunnerRegistry.ExecuteCommandRunnerAsync(serviceProvider, createUserCommand);
             });
     }
 }

--- a/src/core/Wemogy.CQRS/Commands/Mediators/CommandsMediator.cs
+++ b/src/core/Wemogy.CQRS/Commands/Mediators/CommandsMediator.cs
@@ -14,29 +14,32 @@ public class CommandsMediator : ICommands
     private readonly RecurringCommandRunnerRegistry _recurringCommandRunnerRegistry;
     private readonly IScheduledCommandService? _scheduledCommandService;
     private readonly IRecurringCommandService? _recurringCommandService;
+    private readonly IServiceProvider _serviceProvider;
 
     public CommandsMediator(
         CommandRunnerRegistry commandRunnerRegistry,
         ScheduledCommandRunnerRegistry scheduledCommandRunnerRegistry,
         RecurringCommandRunnerRegistry recurringCommandRunnerRegistry,
+        IServiceProvider serviceProvider,
         IScheduledCommandService? scheduledCommandService = null,
         IRecurringCommandService? recurringCommandService = null)
     {
         _commandRunnerRegistry = commandRunnerRegistry;
         _scheduledCommandRunnerRegistry = scheduledCommandRunnerRegistry;
         _recurringCommandRunnerRegistry = recurringCommandRunnerRegistry;
+        _serviceProvider = serviceProvider;
         _scheduledCommandService = scheduledCommandService;
         _recurringCommandService = recurringCommandService;
     }
 
     public Task<TResult> RunAsync<TResult>(ICommand<TResult> command)
     {
-        return _commandRunnerRegistry.ExecuteCommandRunnerAsync(command);
+        return _commandRunnerRegistry.ExecuteCommandRunnerAsync(_serviceProvider, command);
     }
 
     public Task RunAsync(ICommand command)
     {
-        return _commandRunnerRegistry.ExecuteCommandRunnerAsync(command);
+        return _commandRunnerRegistry.ExecuteCommandRunnerAsync(_serviceProvider, command);
     }
 
     public Task<string> ScheduleAsync<TCommand>(TCommand command, TimeSpan delay = default)
@@ -55,6 +58,7 @@ public class CommandsMediator : ICommands
         where TCommand : ICommandBase
     {
         return _scheduledCommandRunnerRegistry.ExecuteScheduledCommandRunnerAsync(
+            _serviceProvider,
             command,
             new ScheduleOptions<TCommand>(delayOptions));
     }
@@ -63,6 +67,7 @@ public class CommandsMediator : ICommands
         where TCommand : ICommandBase
     {
         return _scheduledCommandRunnerRegistry.ExecuteScheduledCommandRunnerAsync(
+            _serviceProvider,
             command,
             new ScheduleOptions<TCommand>(throttleOptions));
     }
@@ -86,6 +91,7 @@ public class CommandsMediator : ICommands
         string cronExpression)
     {
         return _recurringCommandRunnerRegistry.ExecuteRecurringCommandRunnerAsync(
+            _serviceProvider,
             name,
             command,
             cronExpression);

--- a/src/core/Wemogy.CQRS/Commands/Registries/CommandRunnerRegistry.cs
+++ b/src/core/Wemogy.CQRS/Commands/Registries/CommandRunnerRegistry.cs
@@ -12,17 +12,10 @@ namespace Wemogy.CQRS.Commands.Registries;
 
 public class CommandRunnerRegistry : RegistryBase<Type, TypeMethodRegistryEntry>
 {
-    private readonly IServiceProvider _serviceProvider;
-
-    public CommandRunnerRegistry(IServiceProvider serviceProvider)
-    {
-        _serviceProvider = serviceProvider;
-    }
-
-    public Task ExecuteCommandRunnerAsync(ICommand command)
+    public Task ExecuteCommandRunnerAsync(IServiceProvider serviceProvider, ICommand command)
     {
         var commandRunnerEntry = GetCommandRunnerEntry(command);
-        return ExecuteCommandRunnerAsync(commandRunnerEntry, command);
+        return ExecuteCommandRunnerAsync(serviceProvider, commandRunnerEntry, command);
     }
 
     private TypeMethodRegistryEntry GetCommandRunnerEntry(ICommand command)
@@ -32,17 +25,17 @@ public class CommandRunnerRegistry : RegistryBase<Type, TypeMethodRegistryEntry>
         return commandRunnerEntry;
     }
 
-    private Task ExecuteCommandRunnerAsync(TypeMethodRegistryEntry commandRunnerEntry, ICommand command)
+    private Task ExecuteCommandRunnerAsync(IServiceProvider serviceProvider, TypeMethodRegistryEntry commandRunnerEntry, ICommand command)
     {
-        object commandRunner = _serviceProvider.GetRequiredService(commandRunnerEntry.Type);
+        object commandRunner = serviceProvider.GetRequiredService(commandRunnerEntry.Type);
         dynamic res = commandRunnerEntry.Method.Invoke(commandRunner, new object[] { command });
         return res;
     }
 
-    public Task<TResult> ExecuteCommandRunnerAsync<TResult>(ICommand<TResult> command)
+    public Task<TResult> ExecuteCommandRunnerAsync<TResult>(IServiceProvider serviceProvider, ICommand<TResult> command)
     {
         var commandRunnerEntry = GetCommandRunnerEntry(command);
-        return ExecuteCommandRunnerAsync(commandRunnerEntry, command);
+        return ExecuteCommandRunnerAsync(serviceProvider, commandRunnerEntry, command);
     }
 
     private TypeMethodRegistryEntry GetCommandRunnerEntry<TResult>(ICommand<TResult> command)
@@ -52,9 +45,12 @@ public class CommandRunnerRegistry : RegistryBase<Type, TypeMethodRegistryEntry>
         return commandRunnerEntry;
     }
 
-    private Task<TResult> ExecuteCommandRunnerAsync<TResult>(TypeMethodRegistryEntry commandRunnerEntry, ICommand<TResult> command)
+    private Task<TResult> ExecuteCommandRunnerAsync<TResult>(
+        IServiceProvider serviceProvider,
+        TypeMethodRegistryEntry commandRunnerEntry,
+        ICommand<TResult> command)
     {
-        object commandRunner = _serviceProvider.GetRequiredService(commandRunnerEntry.Type);
+        object commandRunner = serviceProvider.GetRequiredService(commandRunnerEntry.Type);
         dynamic res = commandRunnerEntry.Method.Invoke(commandRunner, new object[] { command });
         return res;
     }

--- a/src/core/Wemogy.CQRS/Commands/Registries/RecurringCommandRunnerRegistry.cs
+++ b/src/core/Wemogy.CQRS/Commands/Registries/RecurringCommandRunnerRegistry.cs
@@ -12,14 +12,8 @@ namespace Wemogy.CQRS.Commands.Registries;
 
 public class RecurringCommandRunnerRegistry : RegistryBase<Type, TypeMethodRegistryEntry>
 {
-    private readonly IServiceProvider _serviceProvider;
-
-    public RecurringCommandRunnerRegistry(IServiceProvider serviceProvider)
-    {
-        _serviceProvider = serviceProvider;
-    }
-
     public Task ExecuteRecurringCommandRunnerAsync(
+        IServiceProvider serviceProvider,
         string recurringCommandId,
         ICommandBase command,
         string cronExpression)
@@ -27,6 +21,7 @@ public class RecurringCommandRunnerRegistry : RegistryBase<Type, TypeMethodRegis
         var recurringCommandRunnerEntry = GetRecurringCommandRunnerEntry(command);
         return ExecuteRecurringCommandRunnerAsync(
             recurringCommandRunnerEntry,
+            serviceProvider,
             recurringCommandId,
             command,
             cronExpression);
@@ -41,11 +36,12 @@ public class RecurringCommandRunnerRegistry : RegistryBase<Type, TypeMethodRegis
 
     private Task ExecuteRecurringCommandRunnerAsync(
         TypeMethodRegistryEntry recurringCommandRunnerEntry,
+        IServiceProvider serviceProvider,
         string recurringCommandId,
         ICommandBase command,
         string cronExpression)
     {
-        object recurringCommandRunner = _serviceProvider.GetRequiredService(recurringCommandRunnerEntry.Type);
+        object recurringCommandRunner = serviceProvider.GetRequiredService(recurringCommandRunnerEntry.Type);
         var parameters = new object[]
         {
             recurringCommandId,

--- a/src/core/Wemogy.CQRS/Commands/Registries/ScheduledCommandRunnerRegistry.cs
+++ b/src/core/Wemogy.CQRS/Commands/Registries/ScheduledCommandRunnerRegistry.cs
@@ -13,14 +13,8 @@ namespace Wemogy.CQRS.Commands.Registries;
 
 public class ScheduledCommandRunnerRegistry : RegistryBase<Type, TypeMethodRegistryEntry>
 {
-    private readonly IServiceProvider _serviceProvider;
-
-    public ScheduledCommandRunnerRegistry(IServiceProvider serviceProvider)
-    {
-        _serviceProvider = serviceProvider;
-    }
-
     public Task<string> ExecuteScheduledCommandRunnerAsync<TCommand>(
+        IServiceProvider serviceProvider,
         TCommand command,
         ScheduleOptions<TCommand> scheduleOptions)
         where TCommand : ICommandBase
@@ -28,6 +22,7 @@ public class ScheduledCommandRunnerRegistry : RegistryBase<Type, TypeMethodRegis
         var scheduledCommandRunnerEntry = GetScheduledCommandRunnerEntry(command);
         return ExecuteScheduledCommandRunnerAsync(
             scheduledCommandRunnerEntry,
+            serviceProvider,
             command,
             scheduleOptions);
     }
@@ -41,11 +36,12 @@ public class ScheduledCommandRunnerRegistry : RegistryBase<Type, TypeMethodRegis
 
     private Task<string> ExecuteScheduledCommandRunnerAsync<TCommand>(
         TypeMethodRegistryEntry scheduledCommandRunnerEntry,
+        IServiceProvider serviceProvider,
         TCommand command,
         ScheduleOptions<TCommand> scheduleOptions)
         where TCommand : ICommandBase
     {
-        object scheduledCommandRunner = _serviceProvider.GetRequiredService(scheduledCommandRunnerEntry.Type);
+        object scheduledCommandRunner = serviceProvider.GetRequiredService(scheduledCommandRunnerEntry.Type);
         var parameters = new object[]
         {
             command,

--- a/src/core/Wemogy.CQRS/Common/Abstractions/RegistryBase.cs
+++ b/src/core/Wemogy.CQRS/Common/Abstractions/RegistryBase.cs
@@ -4,11 +4,11 @@ namespace Wemogy.CQRS.Common.Abstractions;
 
 public abstract class RegistryBase<TKey, TValue>
 {
-    private static readonly ConcurrentDictionary<TKey, TValue> EntriesCache = new ConcurrentDictionary<TKey, TValue>();
+    private readonly ConcurrentDictionary<TKey, TValue> _entriesCache = new ConcurrentDictionary<TKey, TValue>();
 
     protected TValue GetRegistryEntry(TKey key)
     {
-        return EntriesCache.GetOrAdd(key, InitializeEntry);
+        return _entriesCache.GetOrAdd(key, InitializeEntry);
     }
 
     protected abstract TValue InitializeEntry(TKey key);

--- a/src/core/Wemogy.CQRS/DependencyInjection.cs
+++ b/src/core/Wemogy.CQRS/DependencyInjection.cs
@@ -115,9 +115,9 @@ public static class DependencyInjection
         serviceCollection.AddScoped<ICommands, CommandsMediator>();
 
         // Add Registries
-        serviceCollection.AddScoped<CommandRunnerRegistry>();
-        serviceCollection.AddScoped<ScheduledCommandRunnerRegistry>();
-        serviceCollection.AddScoped<RecurringCommandRunnerRegistry>();
+        serviceCollection.AddSingleton<CommandRunnerRegistry>();
+        serviceCollection.AddSingleton<ScheduledCommandRunnerRegistry>();
+        serviceCollection.AddSingleton<RecurringCommandRunnerRegistry>();
     }
 
     private static void AddQueries(this IServiceCollection serviceCollection, List<Assembly> assemblies)
@@ -161,7 +161,7 @@ public static class DependencyInjection
         serviceCollection.AddScoped<IQueries, QueriesMediator>();
 
         // Add QueryRunnerRegistry
-        serviceCollection.AddScoped<QueryRunnerRegistry>();
+        serviceCollection.AddSingleton<QueryRunnerRegistry>();
     }
 
     private static void AddImplementation(

--- a/src/core/Wemogy.CQRS/Queries/Mediators/QueriesMediator.cs
+++ b/src/core/Wemogy.CQRS/Queries/Mediators/QueriesMediator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Wemogy.CQRS.Queries.Abstractions;
@@ -8,14 +9,16 @@ namespace Wemogy.CQRS.Queries.Mediators;
 public class QueriesMediator : IQueries
 {
     private readonly QueryRunnerRegistry _queryRunnerRegistry;
+    private readonly IServiceProvider _serviceProvider;
 
-    public QueriesMediator(QueryRunnerRegistry queryRunnerRegistry)
+    public QueriesMediator(QueryRunnerRegistry queryRunnerRegistry, IServiceProvider serviceProvider)
     {
         _queryRunnerRegistry = queryRunnerRegistry;
+        _serviceProvider = serviceProvider;
     }
 
     public Task<TResult> QueryAsync<TResult>(IQuery<TResult> query, CancellationToken cancellationToken = default)
     {
-        return _queryRunnerRegistry.ExecuteQueryRunnerAsync(query, cancellationToken);
+        return _queryRunnerRegistry.ExecuteQueryRunnerAsync(_serviceProvider, query, cancellationToken);
     }
 }

--- a/src/core/Wemogy.CQRS/Queries/Registries/QueryRunnerRegistry.cs
+++ b/src/core/Wemogy.CQRS/Queries/Registries/QueryRunnerRegistry.cs
@@ -13,17 +13,13 @@ namespace Wemogy.CQRS.Queries.Registries;
 
 public class QueryRunnerRegistry : RegistryBase<Type, TypeMethodRegistryEntry>
 {
-    private readonly IServiceProvider _serviceProvider;
-
-    public QueryRunnerRegistry(IServiceProvider serviceProvider)
-    {
-        _serviceProvider = serviceProvider;
-    }
-
-    public Task<TResult> ExecuteQueryRunnerAsync<TResult>(IQuery<TResult> query, CancellationToken cancellationToken)
+    public Task<TResult> ExecuteQueryRunnerAsync<TResult>(
+        IServiceProvider serviceProvider,
+        IQuery<TResult> query,
+        CancellationToken cancellationToken)
     {
         var queryRunnerEntry = GetQueryRunnerEntry(query);
-        return ExecuteQueryRunnerAsync(queryRunnerEntry, query, cancellationToken);
+        return ExecuteQueryRunnerAsync(queryRunnerEntry, serviceProvider, query, cancellationToken);
     }
 
     private TypeMethodRegistryEntry GetQueryRunnerEntry<TResult>(IQuery<TResult> query)
@@ -35,10 +31,11 @@ public class QueryRunnerRegistry : RegistryBase<Type, TypeMethodRegistryEntry>
 
     private Task<TResult> ExecuteQueryRunnerAsync<TResult>(
         TypeMethodRegistryEntry queryRunnerEntry,
+        IServiceProvider serviceProvider,
         IQuery<TResult> query,
         CancellationToken cancellationToken)
     {
-        var queryRunner = _serviceProvider.GetRequiredService(queryRunnerEntry.Type);
+        var queryRunner = serviceProvider.GetRequiredService(queryRunnerEntry.Type);
         dynamic res = queryRunnerEntry.Method.Invoke(queryRunner, new object[] { query, cancellationToken });
         return res;
     }

--- a/src/extensions/azureServiceBus/Wemogy.CQRS.Extensions.AzureServiceBus.UnitTests/Services/AzureServiceBusScheduledCommandServiceTests.cs
+++ b/src/extensions/azureServiceBus/Wemogy.CQRS.Extensions.AzureServiceBus.UnitTests/Services/AzureServiceBusScheduledCommandServiceTests.cs
@@ -75,6 +75,23 @@ public class AzureServiceBusScheduledCommandServiceTests
         PrintContextCommandHandler.ExecutedCount[command.Id].Should().Be(1);
     }
 
+    [Fact]
+    public async Task ScheduleAsync_ShouldWorkWhenCommandRunnerWasUsedBefore()
+    {
+        // Arrange
+        var command = new PrintContextCommand();
+        await StartHostedServiceAsync();
+        await _commands.RunAsync(command);
+        PrintContextCommandHandler.ExecutedCount.Clear();
+
+        // Act
+        await _commands.ScheduleAsync(command);
+
+        // Assert
+        await Task.Delay(TimeSpan.FromSeconds(1));
+        PrintContextCommandHandler.ExecutedCount[command.Id].Should().Be(1);
+    }
+
     private async Task StartHostedServiceAsync()
     {
         var hostedService = _serviceProvider


### PR DESCRIPTION
We had the issue that in the CommandRunnerRegistry, we had ScheduledCommandRunnerEntries due to the static cache. So we isolated them by making them singletons