### PR TITLE
Optimize DI runner registration with open generics

### DIFF
--- a/.github/servicebus-emulator/Config.json
+++ b/.github/servicebus-emulator/Config.json
@@ -1,0 +1,59 @@
+{
+  "UserConfig": {
+    "Namespaces": [
+      {
+        "Name": "sbemulatorns",
+        "Queues": [
+          {
+            "Name": "unit-testing-queue-1",
+            "Properties": {
+              "DeadLetteringOnMessageExpiration": false,
+              "DefaultMessageTimeToLive": "PT1H",
+              "LockDuration": "PT1M",
+              "MaxDeliveryCount": 3,
+              "RequiresDuplicateDetection": false,
+              "RequiresSession": false
+            }
+          },
+          {
+            "Name": "printhelloworld",
+            "Properties": {
+              "DeadLetteringOnMessageExpiration": false,
+              "DefaultMessageTimeToLive": "PT1H",
+              "LockDuration": "PT1M",
+              "MaxDeliveryCount": 3,
+              "RequiresDuplicateDetection": false,
+              "RequiresSession": false
+            }
+          },
+          {
+            "Name": "unit-testing-queue-sessions",
+            "Properties": {
+              "DeadLetteringOnMessageExpiration": false,
+              "DefaultMessageTimeToLive": "PT1H",
+              "LockDuration": "PT1M",
+              "MaxDeliveryCount": 3,
+              "RequiresDuplicateDetection": false,
+              "RequiresSession": true
+            }
+          },
+          {
+            "Name": "unit-testing-queue-duplicate-detection",
+            "Properties": {
+              "DeadLetteringOnMessageExpiration": false,
+              "DefaultMessageTimeToLive": "PT1H",
+              "DuplicateDetectionHistoryTimeWindow": "PT1M",
+              "LockDuration": "PT1M",
+              "MaxDeliveryCount": 3,
+              "RequiresDuplicateDetection": true,
+              "RequiresSession": false
+            }
+          }
+        ]
+      }
+    ],
+    "Logging": {
+      "Type": "File"
+    }
+  }
+}

--- a/.github/servicebus-emulator/docker-compose.yaml
+++ b/.github/servicebus-emulator/docker-compose.yaml
@@ -1,0 +1,37 @@
+name: microsoft-azure-servicebus-emulator
+
+services:
+  emulator:
+    container_name: "servicebus-emulator"
+    image: mcr.microsoft.com/azure-messaging/servicebus-emulator:latest
+    pull_policy: always
+    volumes:
+      - "./Config.json:/ServiceBus_Emulator/ConfigFiles/Config.json"
+    ports:
+      - "5672:5672"
+      - "5300:5300"
+    environment:
+      SQL_SERVER: mssql
+      MSSQL_SA_PASSWORD: "${MSSQL_SA_PASSWORD}"
+      ACCEPT_EULA: "${ACCEPT_EULA:-Y}"
+      EMULATOR_HTTP_PORT: 5300
+    depends_on:
+      - mssql
+    networks:
+      sb-emulator:
+        aliases:
+          - "sb-emulator"
+
+  mssql:
+    container_name: "mssql"
+    image: "mcr.microsoft.com/mssql/server:2022-latest"
+    networks:
+      sb-emulator:
+        aliases:
+          - "mssql"
+    environment:
+      ACCEPT_EULA: "${ACCEPT_EULA:-Y}"
+      MSSQL_SA_PASSWORD: "${MSSQL_SA_PASSWORD}"
+
+networks:
+  sb-emulator:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,6 +16,31 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      # Start the Azure Service Bus emulator (plus its SQL Server dependency)
+      # so the tests can run against a local Service Bus instead of a real namespace.
+      - name: Start Azure Service Bus emulator
+        working-directory: .github/servicebus-emulator
+        shell: bash
+        env:
+          ACCEPT_EULA: "Y"
+          MSSQL_SA_PASSWORD: "Local(!)Password123"
+        run: docker compose up -d --wait
+
+      - name: Wait for Azure Service Bus emulator to be ready
+        shell: bash
+        run: |
+          for i in {1..30}; do
+            if curl -sf http://localhost:5300/health > /dev/null; then
+              echo "Service Bus emulator is ready"
+              exit 0
+            fi
+            echo "Waiting for Service Bus emulator... ($i/30)"
+            sleep 5
+          done
+          echo "Service Bus emulator did not become ready in time"
+          docker compose -f .github/servicebus-emulator/docker-compose.yaml logs
+          exit 1
+
       # .NET Tests
       - name: Build .NET
         uses: ./.github/actions/dotnet
@@ -27,7 +52,13 @@ jobs:
         shell: bash
         run: dotnet test -c Release /p:CollectCoverage=true -m:1
         env:
-          AzureServiceBusConnectionString: ${{ secrets.AZURE_SERVICE_BUS_CONNECTION_STRING }}
+          AzureServiceBusConnectionString: "Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;"
+
+      - name: Stop Azure Service Bus emulator
+        if: always()
+        working-directory: .github/servicebus-emulator
+        shell: bash
+        run: docker compose down -v
 
       - name: Code Coverage Summary Report
         uses: irongut/CodeCoverageSummary@v1.0.2

--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,133 @@
+# the name by which the project can be referenced within Serena
+project_name: "libs-cqrs"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   svelte              swift               systemverilog       terraform           toml
+#   typescript          typescript_vts      vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- csharp
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+fixed_tools: []
+
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+default_modes:
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []

--- a/src/core/Wemogy.CQRS/DependencyInjection.cs
+++ b/src/core/Wemogy.CQRS/DependencyInjection.cs
@@ -76,7 +76,7 @@ public static class DependencyInjection
     {
         var commandTypes = assemblies.GetClassTypesWhichImplementInterface(typeof(ICommand<>));
         commandTypes.AddRange(assemblies.GetClassTypesWhichImplementInterface(typeof(ICommand)));
-
+        commandTypes = commandTypes.Distinct().ToList();
         // Register all command runners as open generic types. The DI container closes them on
         // demand, so they only need to be registered once instead of once per command type.
         serviceCollection.AddCommandRunners();

--- a/src/core/Wemogy.CQRS/DependencyInjection.cs
+++ b/src/core/Wemogy.CQRS/DependencyInjection.cs
@@ -21,7 +21,6 @@ using Wemogy.CQRS.Queries.Registries;
 using Wemogy.CQRS.Queries.Runners;
 using Wemogy.CQRS.Resolvers;
 using Wemogy.CQRS.Setup;
-using Exception = System.Exception;
 
 namespace Wemogy.CQRS;
 
@@ -78,6 +77,10 @@ public static class DependencyInjection
         var commandTypes = assemblies.GetClassTypesWhichImplementInterface(typeof(ICommand<>));
         commandTypes.AddRange(assemblies.GetClassTypesWhichImplementInterface(typeof(ICommand)));
 
+        // Register all command runners as open generic types. The DI container closes them on
+        // demand, so they only need to be registered once instead of once per command type.
+        serviceCollection.AddCommandRunners();
+
         foreach (var commandType in commandTypes)
         {
             if (!commandType.InheritsOrImplements(typeof(ICommand<>), out Type? genericCommandType) || genericCommandType == null)
@@ -92,16 +95,15 @@ public static class DependencyInjection
 
             var resultType = genericCommandType.GenericTypeArguments.ElementAtOrDefault(0);
 
-            if (resultType == null)
-            {
-                // command runners
-                serviceCollection.AddCommandRunners(commandType);
-            }
-            else
-            {
-                // command runners
-                serviceCollection.AddCommandRunners(commandType, resultType);
-            }
+            // Map IScheduledCommandRunner<TCommand> to the matching concrete runner. This cannot be
+            // expressed as a single open generic registration because the void variant has one type
+            // argument while the result variant has two.
+            var scheduledCommandRunnerType = resultType == null
+                ? typeof(VoidScheduledCommandRunner<>).MakeGenericType(commandType)
+                : typeof(ScheduledCommandRunner<,>).MakeGenericType(commandType, resultType);
+            serviceCollection.AddScoped(
+                typeof(IScheduledCommandRunner<>).MakeGenericType(commandType),
+                scheduledCommandRunnerType);
         }
 
         // PreProcessing
@@ -125,21 +127,9 @@ public static class DependencyInjection
 
     private static void AddQueries(this IServiceCollection serviceCollection, List<Assembly> assemblies)
     {
-        var queryTypes = assemblies.GetClassTypesWhichImplementInterface(typeof(IQuery<>));
-
-        foreach (var queryType in queryTypes)
-        {
-            if (!queryType.InheritsOrImplements(typeof(IQuery<>), out Type? genericQueryType) || genericQueryType == null)
-            {
-                throw new Exception("Query type must inherit from IQuery<>");
-            }
-
-            var resultType = genericQueryType.GenericTypeArguments[0];
-
-            // query runner
-            var queryRunnerType = typeof(QueryRunner<,>).MakeGenericType(queryType, resultType);
-            serviceCollection.AddScoped(queryRunnerType);
-        }
+        // Register the query runner as an open generic type. The DI container closes it on demand,
+        // so it only needs to be registered once instead of once per query type.
+        serviceCollection.TryAddScoped(typeof(QueryRunner<,>));
 
         // IQueryValidator implementations
         serviceCollection.AddImplementationsOfGenericInterfaceScoped(typeof(IQueryValidator<>), assemblies);
@@ -157,23 +147,26 @@ public static class DependencyInjection
         serviceCollection.TryAddSingleton<QueryRunnerRegistry>();
     }
 
-    private static void AddImplementation(
-        this IServiceCollection serviceCollection,
-        Type genericImplementationType,
-        Type commandType,
-        Type resultType)
+    private static void AddCommandRunners(this IServiceCollection serviceCollection)
     {
-        var implementationType = genericImplementationType.MakeGenericType(commandType, resultType);
-        serviceCollection.AddScoped(implementationType);
-    }
+        // command runners
+        serviceCollection.TryAddScoped(typeof(VoidCommandRunner<>));
+        serviceCollection.TryAddScoped(typeof(CommandRunner<,>));
 
-    private static void AddImplementation(
-        this IServiceCollection serviceCollection,
-        Type genericImplementationType,
-        Type commandType)
-    {
-        var implementationType = genericImplementationType.MakeGenericType(commandType);
-        serviceCollection.AddScoped(implementationType);
+        // scheduled command runners
+        serviceCollection.TryAddScoped(typeof(VoidScheduledCommandRunner<>));
+        serviceCollection.TryAddScoped(typeof(ScheduledCommandRunner<,>));
+
+        // recurring command runners
+        serviceCollection.TryAddScoped(typeof(VoidRecurringCommandRunner<>));
+        serviceCollection.TryAddScoped(typeof(RecurringCommandRunner<,>));
+
+        // PreProcessingRunner
+        serviceCollection.TryAddScoped(typeof(PreProcessingRunner<>));
+
+        // PostProcessingRunner
+        serviceCollection.TryAddScoped(typeof(PostProcessingRunner<,>));
+        serviceCollection.TryAddScoped(typeof(VoidPostProcessingRunner<>));
     }
 
     private static void AddPreProcessingServices(
@@ -203,65 +196,6 @@ public static class DependencyInjection
         serviceCollection.AddImplementationsOfGenericInterfaceScoped(
             typeof(ICommandPostProcessor<,>),
             assemblies);
-    }
-
-    private static void AddCommandRunners(
-        this IServiceCollection serviceCollection,
-        Type commandType,
-        Type resultType)
-    {
-        // command runner
-        serviceCollection.TryAddScopedGenericType(
-            typeof(CommandRunner<,>),
-            commandType,
-            resultType);
-
-        // scheduled command runner
-        var scheduledCommandRunnerType = typeof(ScheduledCommandRunner<,>).MakeGenericType(commandType, resultType);
-        serviceCollection.AddScoped(scheduledCommandRunnerType);
-        serviceCollection.AddScoped(
-            typeof(IScheduledCommandRunner<>).MakeGenericType(commandType),
-            scheduledCommandRunnerType);
-
-        // recurring command runner
-        serviceCollection.TryAddScopedGenericType(
-            typeof(RecurringCommandRunner<,>),
-            commandType,
-            resultType);
-
-        // PreProcessingRunner
-        serviceCollection.AddImplementation(typeof(PreProcessingRunner<>), commandType);
-
-        // PostProcessingRunner
-        serviceCollection.AddImplementation(typeof(PostProcessingRunner<,>), commandType, resultType);
-    }
-
-    private static void AddCommandRunners(
-        this IServiceCollection serviceCollection,
-        Type commandType)
-    {
-        // command runner
-        serviceCollection.TryAddScopedGenericType(
-            typeof(VoidCommandRunner<>),
-            commandType);
-
-        // scheduled command runner
-        var scheduledCommandRunnerType = typeof(VoidScheduledCommandRunner<>).MakeGenericType(commandType);
-        serviceCollection.AddScoped(scheduledCommandRunnerType);
-        serviceCollection.AddScoped(
-            typeof(IScheduledCommandRunner<>).MakeGenericType(commandType),
-            scheduledCommandRunnerType);
-
-        // recurring command runner
-        serviceCollection.TryAddScopedGenericType(
-            typeof(VoidRecurringCommandRunner<>),
-            commandType);
-
-        // PreProcessingRunner
-        serviceCollection.AddImplementation(typeof(PreProcessingRunner<>), commandType);
-
-        // PostProcessingRunner
-        serviceCollection.AddImplementation(typeof(VoidPostProcessingRunner<>), commandType);
     }
 
     /// <summary>

--- a/src/core/Wemogy.CQRS/DependencyInjection.cs
+++ b/src/core/Wemogy.CQRS/DependencyInjection.cs
@@ -77,6 +77,7 @@ public static class DependencyInjection
         var commandTypes = assemblies.GetClassTypesWhichImplementInterface(typeof(ICommand<>));
         commandTypes.AddRange(assemblies.GetClassTypesWhichImplementInterface(typeof(ICommand)));
         commandTypes = commandTypes.Distinct().ToList();
+
         // Register all command runners as open generic types. The DI container closes them on
         // demand, so they only need to be registered once instead of once per command type.
         serviceCollection.AddCommandRunners();


### PR DESCRIPTION
Register command and query runners once as open generic types instead of looping over every discovered command/query type and registering closed generics via reflection. The IScheduledCommandRunner<> interface mapping is kept per-command because the void and result runner variants differ in arity.