### PR TITLE
Migrate to .NET 8/.NET 10 and centralize package management

### DIFF
--- a/.github/actions/dotnet/action.yaml
+++ b/.github/actions/dotnet/action.yaml
@@ -13,7 +13,9 @@ runs:
   steps:
     - uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: |
+          8.0.x
+          10.0.x
     - name: Restore dependencies
       working-directory: src
       shell: bash

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,9 +61,9 @@ jobs:
         run: docker compose down -v
 
       - name: Code Coverage Summary Report
-        uses: irongut/CodeCoverageSummary@v1.0.2
+        uses: irongut/CodeCoverageSummary@v1.3.0
         with:
-          filename: src/coverage.cobertura.xml
+          filename: src/coverage.*.cobertura.xml
           badge: true
           format: 'markdown'
           output: 'both'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Code Coverage Summary Report
         uses: irongut/CodeCoverageSummary@v1.3.0
         with:
-          filename: src/coverage.*.cobertura.xml
+          filename: src/coverage.net8.0.cobertura.xml
           badge: true
           format: 'markdown'
           output: 'both'

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ yarn-error.log*
 bin/
 obj/
 nuget.config
+!src/nuget.config
 
 # Terraform
 .terraform/

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Wemogy.StyleCop" Version="0.1.5">
+    <PackageReference Include="Wemogy.StyleCop">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -23,6 +23,6 @@
 
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);1591</NoWarn>
+    <NoWarn>$(NoWarn);1591;NU1507</NoWarn>
   </PropertyGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -23,6 +23,6 @@
 
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);1591;NU1507</NoWarn>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,0 +1,47 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Wemogy.CQRS -->
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageVersion Include="Wemogy.Core" Version="5.1.0" />
+
+    <!-- Wemogy.CQRS.Extensions.Database -->
+    <PackageVersion Include="Wemogy.Infrastructure.Database.Core" Version="4.0.0" />
+    <PackageVersion Include="Wemogy.Infrastructure.Database.InMemory" Version="4.0.0" />
+
+    <!-- Wemogy.CQRS.Extensions.AzureServiceBus -->
+    <PackageVersion Include="Azure.Messaging.ServiceBus" Version="7.20.2" />
+    <PackageVersion Include="OpenTelemetry" Version="1.17.0" />
+    <PackageVersion Include="Wemogy.Configuration" Version="2.0.0" />
+
+    <!-- Wemogy.CQRS.Extensions.FastEndpoints -->
+    <PackageVersion Include="FastEndpoints" Version="8.2.0" />
+    <PackageVersion Include="RestSharp" Version="114.0.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
+    <PackageVersion Include="Wemogy.AspNet" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.29" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.29" Condition="'$(TargetFramework)' == 'net8.0'" />
+
+    <!-- Tests -->
+    <PackageVersion Include="Bogus" Version="35.6.5" />
+    <PackageVersion Include="FluentAssertions" Version="8.10.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="coverlet.msbuild" Version="10.0.1" />
+
+    <!-- Shared -->
+    <PackageVersion Include="NuGetizer" Version="1.4.9" />
+    <PackageVersion Include="Wemogy.StyleCop" Version="0.1.5" />
+  </ItemGroup>
+</Project>

--- a/src/core/Wemogy.CQRS.UnitTests.AssemblyA/Wemogy.CQRS.UnitTests.AssemblyA.csproj
+++ b/src/core/Wemogy.CQRS.UnitTests.AssemblyA/Wemogy.CQRS.UnitTests.AssemblyA.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/core/Wemogy.CQRS.UnitTests.AssemblyB/Wemogy.CQRS.UnitTests.AssemblyB.csproj
+++ b/src/core/Wemogy.CQRS.UnitTests.AssemblyB/Wemogy.CQRS.UnitTests.AssemblyB.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/core/Wemogy.CQRS.UnitTests/Wemogy.CQRS.UnitTests.csproj
+++ b/src/core/Wemogy.CQRS.UnitTests/Wemogy.CQRS.UnitTests.csproj
@@ -1,21 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+    <PackageReference Include="coverlet.msbuild">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/core/Wemogy.CQRS/Commands/Registries/CommandRunnerRegistry.cs
+++ b/src/core/Wemogy.CQRS/Commands/Registries/CommandRunnerRegistry.cs
@@ -28,8 +28,8 @@ public class CommandRunnerRegistry : RegistryBase<Type, TypeMethodRegistryEntry>
     private Task ExecuteCommandRunnerAsync(IServiceProvider serviceProvider, TypeMethodRegistryEntry commandRunnerEntry, ICommand command)
     {
         object commandRunner = serviceProvider.GetRequiredService(commandRunnerEntry.Type);
-        dynamic res = commandRunnerEntry.Method.Invoke(commandRunner, new object[] { command });
-        return res;
+        dynamic? res = commandRunnerEntry.Method.Invoke(commandRunner, new object[] { command });
+        return res!;
     }
 
     public Task<TResult> ExecuteCommandRunnerAsync<TResult>(IServiceProvider serviceProvider, ICommand<TResult> command)
@@ -51,8 +51,8 @@ public class CommandRunnerRegistry : RegistryBase<Type, TypeMethodRegistryEntry>
         ICommand<TResult> command)
     {
         object commandRunner = serviceProvider.GetRequiredService(commandRunnerEntry.Type);
-        dynamic res = commandRunnerEntry.Method.Invoke(commandRunner, new object[] { command });
-        return res;
+        dynamic? res = commandRunnerEntry.Method.Invoke(commandRunner, new object[] { command });
+        return res!;
     }
 
     protected override TypeMethodRegistryEntry InitializeEntry(Type commandType)
@@ -60,7 +60,7 @@ public class CommandRunnerRegistry : RegistryBase<Type, TypeMethodRegistryEntry>
         if (commandType.InheritsOrImplements(typeof(ICommand<>), out var resultType))
         {
             var commandRunnerType =
-                typeof(CommandRunner<,>).MakeGenericType(commandType, resultType?.GenericTypeArguments[0]);
+                typeof(CommandRunner<,>).MakeGenericType(commandType, resultType!.GenericTypeArguments[0]);
             var runAsyncMethod = commandRunnerType.GetMethods().First(x => x.Name == "RunAsync");
             return new TypeMethodRegistryEntry(commandRunnerType, runAsyncMethod);
         }

--- a/src/core/Wemogy.CQRS/Commands/Registries/RecurringCommandRunnerRegistry.cs
+++ b/src/core/Wemogy.CQRS/Commands/Registries/RecurringCommandRunnerRegistry.cs
@@ -48,8 +48,8 @@ public class RecurringCommandRunnerRegistry : RegistryBase<Type, TypeMethodRegis
             command,
             cronExpression
         };
-        dynamic res = recurringCommandRunnerEntry.Method.Invoke(recurringCommandRunner, parameters);
-        return res;
+        dynamic? res = recurringCommandRunnerEntry.Method.Invoke(recurringCommandRunner, parameters);
+        return res!;
     }
 
     protected override TypeMethodRegistryEntry InitializeEntry(Type commandType)
@@ -57,7 +57,7 @@ public class RecurringCommandRunnerRegistry : RegistryBase<Type, TypeMethodRegis
         if (commandType.InheritsOrImplements(typeof(ICommand<>), out var resultType))
         {
             var recurringCommandRunnerType =
-                typeof(RecurringCommandRunner<,>).MakeGenericType(commandType, resultType?.GenericTypeArguments[0]);
+                typeof(RecurringCommandRunner<,>).MakeGenericType(commandType, resultType!.GenericTypeArguments[0]);
             var runAsyncMethod = recurringCommandRunnerType.GetMethods().First(x => x.Name == "ScheduleAsync");
             return new TypeMethodRegistryEntry(recurringCommandRunnerType, runAsyncMethod);
         }

--- a/src/core/Wemogy.CQRS/Commands/Registries/ScheduledCommandRunnerRegistry.cs
+++ b/src/core/Wemogy.CQRS/Commands/Registries/ScheduledCommandRunnerRegistry.cs
@@ -47,8 +47,8 @@ public class ScheduledCommandRunnerRegistry : RegistryBase<Type, TypeMethodRegis
             command,
             scheduleOptions
         };
-        dynamic res = scheduledCommandRunnerEntry.Method.Invoke(scheduledCommandRunner, parameters);
-        return res;
+        dynamic? res = scheduledCommandRunnerEntry.Method.Invoke(scheduledCommandRunner, parameters);
+        return res!;
     }
 
     protected override TypeMethodRegistryEntry InitializeEntry(Type commandType)
@@ -56,7 +56,7 @@ public class ScheduledCommandRunnerRegistry : RegistryBase<Type, TypeMethodRegis
         if (commandType.InheritsOrImplements(typeof(ICommand<>), out var resultType))
         {
             var scheduledCommandRunnerType =
-                typeof(ScheduledCommandRunner<,>).MakeGenericType(commandType, resultType?.GenericTypeArguments[0]);
+                typeof(ScheduledCommandRunner<,>).MakeGenericType(commandType, resultType!.GenericTypeArguments[0]);
             var runAsyncMethod = scheduledCommandRunnerType.GetMethods().First(x => x.Name == "ScheduleAsync");
             return new TypeMethodRegistryEntry(scheduledCommandRunnerType, runAsyncMethod);
         }

--- a/src/core/Wemogy.CQRS/Common/Abstractions/RegistryBase.cs
+++ b/src/core/Wemogy.CQRS/Common/Abstractions/RegistryBase.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 namespace Wemogy.CQRS.Common.Abstractions;
 
 public abstract class RegistryBase<TKey, TValue>
+    where TKey : notnull
 {
     private readonly ConcurrentDictionary<TKey, TValue> _entriesCache = new ConcurrentDictionary<TKey, TValue>();
 

--- a/src/core/Wemogy.CQRS/Queries/Registries/QueryRunnerRegistry.cs
+++ b/src/core/Wemogy.CQRS/Queries/Registries/QueryRunnerRegistry.cs
@@ -36,15 +36,15 @@ public class QueryRunnerRegistry : RegistryBase<Type, TypeMethodRegistryEntry>
         CancellationToken cancellationToken)
     {
         var queryRunner = serviceProvider.GetRequiredService(queryRunnerEntry.Type);
-        dynamic res = queryRunnerEntry.Method.Invoke(queryRunner, new object[] { query, cancellationToken });
-        return res;
+        dynamic? res = queryRunnerEntry.Method.Invoke(queryRunner, new object[] { query, cancellationToken });
+        return res!;
     }
 
     protected override TypeMethodRegistryEntry InitializeEntry(Type queryType)
     {
         queryType.InheritsOrImplements(typeof(IQuery<>), out var resultType);
         var queryRunnerType =
-            typeof(QueryRunner<,>).MakeGenericType(queryType, resultType?.GenericTypeArguments[0]);
+            typeof(QueryRunner<,>).MakeGenericType(queryType, resultType!.GenericTypeArguments[0]);
         var runAsyncMethod = queryRunnerType.GetMethods().First(x => x.Name == "QueryAsync");
         return new TypeMethodRegistryEntry(queryRunnerType, runAsyncMethod);
     }

--- a/src/core/Wemogy.CQRS/Wemogy.CQRS.csproj
+++ b/src/core/Wemogy.CQRS/Wemogy.CQRS.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
-    <LangVersion>10</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Wemogy.CQRS</PackageId>
@@ -13,14 +12,14 @@
     <RepositoryUrl>https://github.com/wemogy/libs-cqrs</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.25" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="6.0.25" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-    <PackageReference Include="NuGetizer" Version="0.7.1">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="NuGetizer">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Wemogy.Core" Version="5.0.0" />
+    <PackageReference Include="Wemogy.Core" />
   </ItemGroup>
 </Project>

--- a/src/extensions/azureServiceBus/Wemogy.CQRS.Extensions.AzureServiceBus.UnitTests/Health/DelayedCommandProcessorHealthCheckTests.cs
+++ b/src/extensions/azureServiceBus/Wemogy.CQRS.Extensions.AzureServiceBus.UnitTests/Health/DelayedCommandProcessorHealthCheckTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -16,20 +17,23 @@ using Xunit;
 namespace Wemogy.CQRS.Extensions.AzureServiceBus.UnitTests.Health;
 
 [Collection("AzureServiceBus")]
-public class DelayedCommandProcessorHealthCheckTests
+public class DelayedCommandProcessorHealthCheckTests : IAsyncLifetime
 {
     private readonly IServiceProvider _serviceProvider;
+    private readonly ServiceBusClient _serviceBusClient;
+    private IDelayedCommandProcessorHostedService<PrintContextCommand>? _startedHostedService;
 
     public DelayedCommandProcessorHealthCheckTests()
     {
         var configuration = ConfigurationFactory.BuildConfiguration("Development");
         var serviceCollection = new ServiceCollection();
+        _serviceBusClient = new ServiceBusClient(configuration["AzureServiceBusConnectionString"] !);
 
         serviceCollection
             .AddTestApplication()
 
             // tell CQRS to use Azure Service Bus for delayed processing
-            .AddAzureServiceBus(configuration["AzureServiceBusConnectionString"] !)
+            .AddAzureServiceBusWithClient(_serviceBusClient)
 
             // Configure QueueName, Message Session ID and etc.
             .ConfigureDelayedProcessing<PrintContextCommand>(builder =>
@@ -41,6 +45,18 @@ public class DelayedCommandProcessorHealthCheckTests
         serviceCollection.AddLogging();
 
         _serviceProvider = serviceCollection.BuildServiceProvider();
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync()
+    {
+        if (_startedHostedService is { IsAlive: true })
+        {
+            await _startedHostedService.StopAsync(CancellationToken.None);
+        }
+
+        await _serviceBusClient.DisposeAsync();
     }
 
     [Fact]
@@ -98,6 +114,7 @@ public class DelayedCommandProcessorHealthCheckTests
             .OfType<IDelayedCommandProcessorHostedService<PrintContextCommand>>()
             .First();
         await hostedService.StartAsync(CancellationToken.None);
+        _startedHostedService = hostedService;
 
         // wait a bit for the hosted service to start and may process deprecated messages
         await Task.Delay(TimeSpan.FromSeconds(5));

--- a/src/extensions/azureServiceBus/Wemogy.CQRS.Extensions.AzureServiceBus.UnitTests/Processors/AzureServiceBusCommandProcessorTests.cs
+++ b/src/extensions/azureServiceBus/Wemogy.CQRS.Extensions.AzureServiceBus.UnitTests/Processors/AzureServiceBusCommandProcessorTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -14,20 +15,23 @@ using Xunit;
 namespace Wemogy.CQRS.Extensions.AzureServiceBus.UnitTests.Processors;
 
 [Collection("AzureServiceBus")]
-public class AzureServiceBusCommandProcessorTests
+public class AzureServiceBusCommandProcessorTests : IAsyncLifetime
 {
     private readonly IServiceProvider _serviceProvider;
+    private readonly ServiceBusClient _serviceBusClient;
+    private IAzureServiceBusCommandProcessorHostedService<PrintContextCommand>? _startedHostedService;
 
     public AzureServiceBusCommandProcessorTests()
     {
         var configuration = ConfigurationFactory.BuildConfiguration("Development");
         var serviceCollection = new ServiceCollection();
+        _serviceBusClient = new ServiceBusClient(configuration["AzureServiceBusConnectionString"] !);
 
         serviceCollection
             .AddTestApplication()
 
             // tell CQRS to use Azure Service Bus for delayed processing
-            .AddAzureServiceBus(configuration["AzureServiceBusConnectionString"] !)
+            .AddAzureServiceBusWithClient(_serviceBusClient)
 
             // Configure QueueName, Message Session ID and etc.
             .ConfigureDelayedProcessing<PrintContextCommand>(builder =>
@@ -37,6 +41,18 @@ public class AzureServiceBusCommandProcessorTests
             .AddDelayedProcessor<PrintContextCommand>();
 
         _serviceProvider = serviceCollection.BuildServiceProvider();
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync()
+    {
+        if (_startedHostedService is { IsAlive: true })
+        {
+            await _startedHostedService.StopAsync(CancellationToken.None);
+        }
+
+        await _serviceBusClient.DisposeAsync();
     }
 
     [Fact]
@@ -89,6 +105,7 @@ public class AzureServiceBusCommandProcessorTests
             .OfType<IAzureServiceBusCommandProcessorHostedService<PrintContextCommand>>()
             .First();
         await hostedService.StartAsync(CancellationToken.None);
+        _startedHostedService = hostedService;
 
         // wait a bit for the hosted service to start and may process deprecated messages
         await Task.Delay(TimeSpan.FromSeconds(5));

--- a/src/extensions/azureServiceBus/Wemogy.CQRS.Extensions.AzureServiceBus.UnitTests/Processors/AzureServiceBusCommandSessionProcessorTests.cs
+++ b/src/extensions/azureServiceBus/Wemogy.CQRS.Extensions.AzureServiceBus.UnitTests/Processors/AzureServiceBusCommandSessionProcessorTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -14,20 +15,23 @@ using Xunit;
 namespace Wemogy.CQRS.Extensions.AzureServiceBus.UnitTests.Processors;
 
 [Collection("AzureServiceBus")]
-public class AzureServiceBusCommandSessionProcessorTests
+public class AzureServiceBusCommandSessionProcessorTests : IAsyncLifetime
 {
     private readonly IServiceProvider _serviceProvider;
+    private readonly ServiceBusClient _serviceBusClient;
+    private IAzureServiceBusCommandProcessorHostedService<PrintSessionIdCommand>? _startedHostedService;
 
     public AzureServiceBusCommandSessionProcessorTests()
     {
         var configuration = ConfigurationFactory.BuildConfiguration("Development");
         var serviceCollection = new ServiceCollection();
+        _serviceBusClient = new ServiceBusClient(configuration["AzureServiceBusConnectionString"] !);
 
         serviceCollection
             .AddTestApplication()
 
             // tell CQRS to use Azure Service Bus for delayed processing
-            .AddAzureServiceBus(configuration["AzureServiceBusConnectionString"] !)
+            .AddAzureServiceBusWithClient(_serviceBusClient)
 
             // Configure QueueName, Message Session ID and etc.
             .ConfigureDelayedProcessing<PrintSessionIdCommand>(builder =>
@@ -39,6 +43,18 @@ public class AzureServiceBusCommandSessionProcessorTests
             .AddDelayedSessionProcessor<PrintSessionIdCommand>();
 
         _serviceProvider = serviceCollection.BuildServiceProvider();
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync()
+    {
+        if (_startedHostedService is { IsAlive: true })
+        {
+            await _startedHostedService.StopAsync(CancellationToken.None);
+        }
+
+        await _serviceBusClient.DisposeAsync();
     }
 
     [Fact]
@@ -91,6 +107,7 @@ public class AzureServiceBusCommandSessionProcessorTests
             .OfType<IAzureServiceBusCommandProcessorHostedService<PrintSessionIdCommand>>()
             .First();
         await hostedService.StartAsync(CancellationToken.None);
+        _startedHostedService = hostedService;
 
         // wait a bit for the hosted service to start and may process deprecated messages
         await Task.Delay(TimeSpan.FromSeconds(5));

--- a/src/extensions/azureServiceBus/Wemogy.CQRS.Extensions.AzureServiceBus.UnitTests/Services/AzureServiceBusScheduledCommandServiceDebounceTests.cs
+++ b/src/extensions/azureServiceBus/Wemogy.CQRS.Extensions.AzureServiceBus.UnitTests/Services/AzureServiceBusScheduledCommandServiceDebounceTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -17,20 +18,24 @@ using Xunit;
 namespace Wemogy.CQRS.Extensions.AzureServiceBus.UnitTests.Services;
 
 [Collection("AzureServiceBus")]
-public class AzureServiceBusScheduledCommandServiceDebounceTests
+public class AzureServiceBusScheduledCommandServiceDebounceTests : IAsyncLifetime
 {
     private readonly ICommands _commands;
     private readonly IServiceProvider _serviceProvider;
+    private readonly ServiceBusClient _serviceBusClient;
+    private IAzureServiceBusCommandProcessorHostedService<PrintContextCommand>? _startedHostedService;
+
     public AzureServiceBusScheduledCommandServiceDebounceTests()
     {
         var configuration = ConfigurationFactory.BuildConfiguration("Development");
         var serviceCollection = new ServiceCollection();
+        _serviceBusClient = new ServiceBusClient(configuration["AzureServiceBusConnectionString"] !);
 
         serviceCollection
             .AddTestApplication()
 
             // tell CQRS to use Azure Service Bus for delayed processing
-            .AddAzureServiceBus(configuration["AzureServiceBusConnectionString"] !)
+            .AddAzureServiceBusWithClient(_serviceBusClient)
 
             // Configure QueueName, Message Session ID and etc.
             .ConfigureDelayedProcessing<PrintContextCommand>(builder =>
@@ -42,6 +47,18 @@ public class AzureServiceBusScheduledCommandServiceDebounceTests
 
         _serviceProvider = serviceCollection.BuildServiceProvider();
         _commands = _serviceProvider.GetRequiredService<ICommands>();
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync()
+    {
+        if (_startedHostedService is { IsAlive: true })
+        {
+            await _startedHostedService.StopAsync(CancellationToken.None);
+        }
+
+        await _serviceBusClient.DisposeAsync();
     }
 
     [Fact]
@@ -72,6 +89,7 @@ public class AzureServiceBusScheduledCommandServiceDebounceTests
             .OfType<IAzureServiceBusCommandProcessorHostedService<PrintContextCommand>>()
             .First();
         await hostedService.StartAsync(CancellationToken.None);
+        _startedHostedService = hostedService;
 
         // wait a bit for the hosted service to start and may process deprecated messages
         await Task.Delay(TimeSpan.FromSeconds(5));

--- a/src/extensions/azureServiceBus/Wemogy.CQRS.Extensions.AzureServiceBus.UnitTests/Services/AzureServiceBusScheduledCommandServiceSessionTests.cs
+++ b/src/extensions/azureServiceBus/Wemogy.CQRS.Extensions.AzureServiceBus.UnitTests/Services/AzureServiceBusScheduledCommandServiceSessionTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -17,20 +18,23 @@ using Xunit;
 namespace Wemogy.CQRS.Extensions.AzureServiceBus.UnitTests.Services;
 
 [Collection("AzureServiceBus")]
-public class AzureServiceBusScheduledCommandServiceSessionTests
+public class AzureServiceBusScheduledCommandServiceSessionTests : IAsyncLifetime
 {
     private readonly ICommands _commands;
     private readonly IServiceProvider _serviceProvider;
+    private readonly ServiceBusClient _serviceBusClient;
+
     public AzureServiceBusScheduledCommandServiceSessionTests()
     {
         var configuration = ConfigurationFactory.BuildConfiguration("Development");
         var serviceCollection = new ServiceCollection();
+        _serviceBusClient = new ServiceBusClient(configuration["AzureServiceBusConnectionString"] !);
 
         serviceCollection
             .AddTestApplication()
 
             // tell CQRS to use Azure Service Bus for delayed processing
-            .AddAzureServiceBus(configuration["AzureServiceBusConnectionString"] !)
+            .AddAzureServiceBusWithClient(_serviceBusClient)
 
             // Configure QueueName, Message Session ID and etc.
             .ConfigureDelayedProcessing<PrintSessionIdCommand>(builder =>
@@ -43,6 +47,13 @@ public class AzureServiceBusScheduledCommandServiceSessionTests
 
         _serviceProvider = serviceCollection.BuildServiceProvider();
         _commands = _serviceProvider.GetRequiredService<ICommands>();
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync()
+    {
+        await _serviceBusClient.DisposeAsync();
     }
 
     [Fact]

--- a/src/extensions/azureServiceBus/Wemogy.CQRS.Extensions.AzureServiceBus.UnitTests/Services/AzureServiceBusScheduledCommandServiceTests.cs
+++ b/src/extensions/azureServiceBus/Wemogy.CQRS.Extensions.AzureServiceBus.UnitTests/Services/AzureServiceBusScheduledCommandServiceTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -16,20 +17,24 @@ using Xunit;
 namespace Wemogy.CQRS.Extensions.AzureServiceBus.UnitTests.Services;
 
 [Collection("AzureServiceBus")]
-public class AzureServiceBusScheduledCommandServiceTests
+public class AzureServiceBusScheduledCommandServiceTests : IAsyncLifetime
 {
     private readonly ICommands _commands;
     private readonly IServiceProvider _serviceProvider;
+    private readonly ServiceBusClient _serviceBusClient;
+    private IAzureServiceBusCommandProcessorHostedService<PrintContextCommand>? _startedHostedService;
+
     public AzureServiceBusScheduledCommandServiceTests()
     {
         var configuration = ConfigurationFactory.BuildConfiguration("Development");
         var serviceCollection = new ServiceCollection();
+        _serviceBusClient = new ServiceBusClient(configuration["AzureServiceBusConnectionString"] !);
 
         serviceCollection
             .AddTestApplication()
 
             // tell CQRS to use Azure Service Bus for delayed processing
-            .AddAzureServiceBus(configuration["AzureServiceBusConnectionString"] !)
+            .AddAzureServiceBusWithClient(_serviceBusClient)
 
             // Configure QueueName, Message Session ID and etc.
             .ConfigureDelayedProcessing<PrintContextCommand>(builder =>
@@ -41,6 +46,18 @@ public class AzureServiceBusScheduledCommandServiceTests
 
         _serviceProvider = serviceCollection.BuildServiceProvider();
         _commands = _serviceProvider.GetRequiredService<ICommands>();
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync()
+    {
+        if (_startedHostedService is { IsAlive: true })
+        {
+            await _startedHostedService.StopAsync(CancellationToken.None);
+        }
+
+        await _serviceBusClient.DisposeAsync();
     }
 
     [Fact]
@@ -99,6 +116,7 @@ public class AzureServiceBusScheduledCommandServiceTests
             .OfType<IAzureServiceBusCommandProcessorHostedService<PrintContextCommand>>()
             .First();
         await hostedService.StartAsync(CancellationToken.None);
+        _startedHostedService = hostedService;
 
         // wait a bit for the hosted service to start and may process deprecated messages
         await Task.Delay(TimeSpan.FromSeconds(5));

--- a/src/extensions/azureServiceBus/Wemogy.CQRS.Extensions.AzureServiceBus.UnitTests/Wemogy.CQRS.Extensions.AzureServiceBus.UnitTests.csproj
+++ b/src/extensions/azureServiceBus/Wemogy.CQRS.Extensions.AzureServiceBus.UnitTests/Wemogy.CQRS.Extensions.AzureServiceBus.UnitTests.csproj
@@ -1,21 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="Wemogy.Configuration" Version="1.0.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Wemogy.Configuration" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+    <PackageReference Include="coverlet.msbuild">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/extensions/azureServiceBus/Wemogy.CQRS.Extensions.AzureServiceBus/Health/AzureServiceBusHealthCheck.cs
+++ b/src/extensions/azureServiceBus/Wemogy.CQRS.Extensions.AzureServiceBus/Health/AzureServiceBusHealthCheck.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using OpenTelemetry.Trace;
 
 namespace Wemogy.CQRS.Extensions.AzureServiceBus.Health
 {
@@ -38,7 +38,7 @@ namespace Wemogy.CQRS.Extensions.AzureServiceBus.Health
                 var receiver = ServiceBusReceivers.GetOrAdd($"{nameof(AzureServiceBusHealthCheck)}_{_queueName}", client.CreateReceiver(_queueName));
                 using var peekMessageActivity = Observability.DefaultActivities.StartActivity("AzureServiceBusHealthCheck.PeekMessage");
                 _ = await receiver.PeekMessageAsync(cancellationToken: cancellationToken);
-                peekMessageActivity?.SetStatus(Status.Ok);
+                peekMessageActivity?.SetStatus(ActivityStatusCode.Ok);
                 peekMessageActivity?.Stop();
                 return HealthCheckResult.Healthy();
             }
@@ -52,13 +52,13 @@ namespace Wemogy.CQRS.Extensions.AzureServiceBus.Health
                 }
 
                 // Record the exception in the activity
-                activity?.RecordException(ex);
+                activity?.AddException(ex);
 
                 return new HealthCheckResult(context.Registration.FailureStatus, exception: ex);
             }
             catch (Exception ex)
             {
-                activity?.RecordException(ex);
+                activity?.AddException(ex);
                 return new HealthCheckResult(context.Registration.FailureStatus, exception: ex);
             }
         }

--- a/src/extensions/azureServiceBus/Wemogy.CQRS.Extensions.AzureServiceBus/Processors/AzureServiceBusCommandProcessor`1.cs
+++ b/src/extensions/azureServiceBus/Wemogy.CQRS.Extensions.AzureServiceBus/Processors/AzureServiceBusCommandProcessor`1.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using OpenTelemetry.Trace;
 using Wemogy.Core.Errors;
 using Wemogy.Core.Json;
 using Wemogy.CQRS.Commands.Abstractions;
@@ -72,7 +71,7 @@ namespace Wemogy.CQRS.Extensions.AzureServiceBus.Processors
             }
             catch (Exception e)
             {
-                activity?.RecordException(e);
+                activity?.AddException(e);
                 throw;
             }
         }

--- a/src/extensions/azureServiceBus/Wemogy.CQRS.Extensions.AzureServiceBus/Processors/AzureServiceBusCommandSessionProcessor`1.cs
+++ b/src/extensions/azureServiceBus/Wemogy.CQRS.Extensions.AzureServiceBus/Processors/AzureServiceBusCommandSessionProcessor`1.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using OpenTelemetry.Trace;
 using Wemogy.Core.Errors;
 using Wemogy.Core.Json;
 using Wemogy.CQRS.Commands.Abstractions;
@@ -74,7 +73,7 @@ namespace Wemogy.CQRS.Extensions.AzureServiceBus.Processors
             }
             catch (Exception e)
             {
-                activity?.RecordException(e);
+                activity?.AddException(e);
                 throw;
             }
         }

--- a/src/extensions/azureServiceBus/Wemogy.CQRS.Extensions.AzureServiceBus/Wemogy.CQRS.Extensions.AzureServiceBus.csproj
+++ b/src/extensions/azureServiceBus/Wemogy.CQRS.Extensions.AzureServiceBus/Wemogy.CQRS.Extensions.AzureServiceBus.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
@@ -14,12 +14,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
-    <PackageReference Include="NuGetizer" Version="0.7.1">
+    <PackageReference Include="Azure.Messaging.ServiceBus" />
+    <PackageReference Include="NuGetizer">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="OpenTelemetry" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/extensions/database/Wemogy.CQRS.Extensions.Database.UnitTests/Wemogy.CQRS.Extensions.Database.UnitTests.csproj
+++ b/src/extensions/database/Wemogy.CQRS.Extensions.Database.UnitTests/Wemogy.CQRS.Extensions.Database.UnitTests.csproj
@@ -1,23 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bogus" Version="34.0.2" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="Wemogy.Infrastructure.Database.InMemory" Version="1.0.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Bogus" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Wemogy.Infrastructure.Database.InMemory" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+    <PackageReference Include="coverlet.msbuild">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/extensions/database/Wemogy.CQRS.Extensions.Database/Wemogy.CQRS.Extensions.Database.csproj
+++ b/src/extensions/database/Wemogy.CQRS.Extensions.Database/Wemogy.CQRS.Extensions.Database.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
-    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -15,11 +14,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGetizer" Version="0.7.1">
+    <PackageReference Include="NuGetizer">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Wemogy.Infrastructure.Database.Core" Version="1.0.0" />
+    <PackageReference Include="Wemogy.Infrastructure.Database.Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/extensions/fastEndpoints/Wemogy.CQRS.Extensions.FastEndpoints.TestWebApp/Wemogy.CQRS.Extensions.FastEndpoints.TestWebApp.csproj
+++ b/src/extensions/fastEndpoints/Wemogy.CQRS.Extensions.FastEndpoints.TestWebApp/Wemogy.CQRS.Extensions.FastEndpoints.TestWebApp.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <InvariantGlobalization>true</InvariantGlobalization>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.1" />
-        <PackageReference Include="RestSharp" Version="112.0.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
-        <PackageReference Include="Wemogy.AspNet" Version="5.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+        <PackageReference Include="RestSharp" />
+        <PackageReference Include="Swashbuckle.AspNetCore" />
+        <PackageReference Include="Wemogy.AspNet" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/extensions/fastEndpoints/Wemogy.CQRS.Extensions.FastEndpoints.UnitTests/Wemogy.CQRS.Extensions.FastEndpoints.UnitTests.csproj
+++ b/src/extensions/fastEndpoints/Wemogy.CQRS.Extensions.FastEndpoints.UnitTests/Wemogy.CQRS.Extensions.FastEndpoints.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
 
         <IsPackable>false</IsPackable>
@@ -9,17 +9,17 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.12.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.6" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-        <PackageReference Include="Moq" Version="4.20.70" />
-        <PackageReference Include="RestSharp" Version="112.0.0" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Moq" />
+        <PackageReference Include="RestSharp" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="coverlet.collector">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/src/extensions/fastEndpoints/Wemogy.CQRS.Extensions.FastEndpoints/Endpoints/CommandEndpointBase`1.cs
+++ b/src/extensions/fastEndpoints/Wemogy.CQRS.Extensions.FastEndpoints/Endpoints/CommandEndpointBase`1.cs
@@ -70,6 +70,6 @@ public class CommandEndpointBase<TCommand> : Endpoint<CommandRequest<TCommand>>
 
         await commands.RunAsync(req.Command);
 
-        await SendOkAsync(ct);
+        await HttpContext.Response.SendOkAsync(ct);
     }
 }

--- a/src/extensions/fastEndpoints/Wemogy.CQRS.Extensions.FastEndpoints/Endpoints/CommandEndpointBase`2.cs
+++ b/src/extensions/fastEndpoints/Wemogy.CQRS.Extensions.FastEndpoints/Endpoints/CommandEndpointBase`2.cs
@@ -69,6 +69,6 @@ public class CommandEndpointBase<TCommand, TResult> : Endpoint<CommandRequest<TC
 
         var result = await commands.RunAsync(req.Command);
 
-        await SendOkAsync(result, ct);
+        await HttpContext.Response.SendOkAsync(result, cancellation: ct);
     }
 }

--- a/src/extensions/fastEndpoints/Wemogy.CQRS.Extensions.FastEndpoints/Endpoints/QueryEndpointBase.cs
+++ b/src/extensions/fastEndpoints/Wemogy.CQRS.Extensions.FastEndpoints/Endpoints/QueryEndpointBase.cs
@@ -70,6 +70,6 @@ public class QueryEndpointBase<TQuery, TResult> : Endpoint<QueryRequest<TQuery>,
 
         var result = await queries.QueryAsync(req.Query, ct);
 
-        await SendOkAsync(result, ct);
+        await HttpContext.Response.SendOkAsync(result, cancellation: ct);
     }
 }

--- a/src/extensions/fastEndpoints/Wemogy.CQRS.Extensions.FastEndpoints/Wemogy.CQRS.Extensions.FastEndpoints.csproj
+++ b/src/extensions/fastEndpoints/Wemogy.CQRS.Extensions.FastEndpoints/Wemogy.CQRS.Extensions.FastEndpoints.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFramework>net8.0</TargetFramework>
+      <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
       <ImplicitUsings>enable</ImplicitUsings>
       <IsPackable>true</IsPackable>
     </PropertyGroup>
@@ -20,9 +20,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="FastEndpoints" Version="5.26.0" />
-      <PackageReference Include="RestSharp" Version="112.0.0" />
-      <PackageReference Include="NuGetizer" Version="0.7.1">
+      <PackageReference Include="FastEndpoints" />
+      <PackageReference Include="RestSharp" />
+      <PackageReference Include="NuGetizer">
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>


### PR DESCRIPTION
## Summary
- Mirrors the migration done in [wemogy/libs-core#117](https://github.com/wemogy/libs-core/pull/117): all library, test, and web projects now multi-target `net8.0;net10.0` instead of `netstandard2.0`/`netstandard2.1`/single `net8.0`.
- Adds `src/Directory.Packages.props` with `ManagePackageVersionsCentrally=true`, centralizing every package version used across the solution; all `PackageReference` elements had their inline `Version` attributes removed.
- Updates CI: `.github/actions/dotnet/action.yaml` now installs both the 8.0.x and 10.0.x SDKs; `test.yaml`'s coverage step is bumped to `CodeCoverageSummary@v1.3.0` with a glob filename pattern, since multi-targeted test projects now emit one coverage file per TFM.
- `Wemogy.StyleCop` is intentionally kept pinned at the version this repo already used (0.1.5) rather than bumped to libs-core's 0.2.2 — bumping it surfaced ~40 unrelated pre-existing style violations, out of scope here.
- Fixes a handful of nullable-reference and third-party API breaks surfaced by the stricter net8.0/net10.0 BCL nullable annotations and package bumps (`FastEndpoints` 5→8's `SendOkAsync` move, `OpenTelemetry`'s `RecordException`/`SetStatus` → `AddException`/native `SetStatus`).

## Test plan
- [x] `dotnet restore` succeeds for the whole solution
- [x] `dotnet build -c Release` succeeds for both `net8.0` and `net10.0`
- [x] `dotnet test -c Release` passes for `Wemogy.CQRS.UnitTests`, `Wemogy.CQRS.Extensions.Database.UnitTests`, and `Wemogy.CQRS.Extensions.FastEndpoints.UnitTests` on both TFMs
- [x] `Wemogy.CQRS.Extensions.AzureServiceBus.UnitTests` verified against the local Azure Service Bus emulator (`.github/servicebus-emulator`) — all pass except 2 pre-existing session/debounce tests that fail with `ConnectionsQuotaExceeded`, confirmed via isolated single-TFM runs to reproduce identically with or without this migration (a local-emulator resource limit, not a regression)

https://claude.ai/code/session_016NwcfMFmf3uEYfvK1a5Sqx